### PR TITLE
Feature 10 - Novos protocolos para suporte a linguagens

### DIFF
--- a/dwp/common.js
+++ b/dwp/common.js
@@ -8,7 +8,8 @@ const Flags = {
   RESOURCE: 0x01,
   TASKS: 0x02,
   STATE: 0x04,
-  ALIAS: 0x08
+  ALIAS: 0x08,
+  SUPPORTED_LANGUAGES: 0x10
 }
 
 const TerminateTaskCode = {

--- a/dwp/factory.js
+++ b/dwp/factory.js
@@ -12,6 +12,7 @@ const taskResult = require('./pdu/task_result')
 const terminateTask = require('./pdu/terminate_task')
 const terminateTaskResponse = require('./pdu/terminate_task_response')
 const performCommand = require('./pdu/perform_command')
+const languageSupport = require('./pdu/language_support')
 const extend = require('util')._extend
 
 // Protocol Version
@@ -25,7 +26,8 @@ const Id = {
   TASK_RESULT: 4,
   TERMINATE_TASK: 5,
   TERMINATE_TASK_RESPONSE: 6,
-  PERFORM_COMMAND: 7
+  PERFORM_COMMAND: 7,
+  LANGUAGE_SUPPORT: 8
 }
 
 module.exports.Id = Id
@@ -66,6 +68,10 @@ module.exports.validate = function (pdu) {
 
     case Id.PERFORM_COMMAND:
       performCommand.validate(pdu)
+      break
+
+    case Id.LANGUAGE_SUPPORT:
+      languageSupport.validate(pdu)
       break
 
     default:

--- a/dwp/factory.js
+++ b/dwp/factory.js
@@ -12,7 +12,10 @@ const taskResult = require('./pdu/task_result')
 const terminateTask = require('./pdu/terminate_task')
 const terminateTaskResponse = require('./pdu/terminate_task_response')
 const performCommand = require('./pdu/perform_command')
+const getLanguageSupport = require('./pdu/get_language_support')
 const languageSupport = require('./pdu/language_support')
+const getLanguageCommand = require('./pdu/get_language_command')
+const languageCommand = require('./pdu/language_command')
 const extend = require('util')._extend
 
 // Protocol Version
@@ -27,7 +30,10 @@ const Id = {
   TERMINATE_TASK: 5,
   TERMINATE_TASK_RESPONSE: 6,
   PERFORM_COMMAND: 7,
-  LANGUAGE_SUPPORT: 8
+  GET_LANGUAGE_SUPPORT: 8,
+  LANGUAGE_SUPPORT: 9,
+  GET_LANGUAGE_COMMAND: 10,
+  LANGUAGE_COMMAND: 11
 }
 
 module.exports.Id = Id
@@ -70,8 +76,20 @@ module.exports.validate = function (pdu) {
       performCommand.validate(pdu)
       break
 
+    case Id.GET_LANGUAGE_SUPPORT:
+      getLanguageSupport.validate(pdu)
+      break
+
     case Id.LANGUAGE_SUPPORT:
       languageSupport.validate(pdu)
+      break
+
+    case Id.GET_LANGUAGE_COMMAND:
+      getLanguageCommand.validate(pdu)
+      break
+
+    case Id.LANGUAGE_COMMAND:
+      languageCommand.validate(pdu)
       break
 
     default:

--- a/dwp/pdu/get_language_command.js
+++ b/dwp/pdu/get_language_command.js
@@ -15,10 +15,6 @@ const validate = (data) => {
   if (data.name === undefined) {
     throw Object({ error: 'validation error', reason: 'name field is undefined' });
   }
-
-  if (data.command === undefined) {
-    throw Object({ error: 'validation error', reason: 'command field is undefined' });
-  }
 }
 
 const format = (data) => {
@@ -32,7 +28,7 @@ const format = (data) => {
 
   const packet = JSON.stringify(pdu);
 
-  return factory.encapsulate(packet, factory.Id.GET_LANGUAGE_SUPPORT);
+  return factory.encapsulate(packet, factory.Id.GET_LANGUAGE_COMMAND);
 }
 
 module.exports = {

--- a/dwp/pdu/get_language_support.js
+++ b/dwp/pdu/get_language_support.js
@@ -1,0 +1,41 @@
+/// /////////////////////////////////////////////
+//
+// Copyright (c) 2017 Mikael Marques Mello
+//
+/// /////////////////////////////////////////////
+
+const factory = require('../factory');
+const extend = require('util')._extend;
+
+const validate = (data) => {
+  if (data === undefined) {
+    throw Object({ error: 'validation error', reason: 'no data was set' });
+  }
+
+  if (data.name === undefined) {
+    throw Object({ error: 'validation error', reason: 'name field is undefined' });
+  }
+
+  if (data.command === undefined) {
+    throw Object({ error: 'validation error', reason: 'command field is undefined' });
+  }
+}
+
+const format = (data) => {
+  validate(data);
+
+  var pdu = {}
+
+  if (data !== undefined) {
+    pdu = extend(pdu, data);
+  }
+
+  const packet = JSON.stringify(pdu);
+
+  return factory.encapsulate(packet, factory.Id.GET_REPORT);
+}
+
+module.exports = {
+  validate: validate,
+  format: format
+}

--- a/dwp/pdu/language_command.js
+++ b/dwp/pdu/language_command.js
@@ -4,8 +4,8 @@
 //
 /// /////////////////////////////////////////////
 
-const factory = require('../factory');
-const extend = require('util')._extend;
+const factory = require('../factory')
+const extend = require('util')._extend
 
 const validate = (data) => {
   if (data === undefined) {
@@ -32,7 +32,7 @@ const format = (data) => {
 
   const packet = JSON.stringify(pdu);
 
-  return factory.encapsulate(packet, factory.Id.GET_LANGUAGE_SUPPORT);
+  return factory.encapsulate(packet, factory.Id.LANGUAGE_COMMAND);
 }
 
 module.exports = {

--- a/dwp/pdu/language_support.js
+++ b/dwp/pdu/language_support.js
@@ -44,7 +44,7 @@ const format = (data) => {
 
   const packet = JSON.stringify(pdu);
 
-  return factory.encapsulate(packet, factory.Id.TASK_RESULT);
+  return factory.encapsulate(packet, factory.Id.LANGUAGE_SUPPORT);
 }
 
 module.exports = {

--- a/dwp/pdu/language_support.js
+++ b/dwp/pdu/language_support.js
@@ -1,0 +1,53 @@
+/// /////////////////////////////////////////////
+//
+// Copyright (c) 2017 Mikael Marques Mello
+//
+/// /////////////////////////////////////////////
+
+const factory = require('../factory')
+const extend = require('util')._extend
+
+const validate = (data) => {
+  if (data === undefined) {
+    throw Object({ error: 'validation error', reason: 'no data was set' });
+  }
+
+  if (data.language === undefined) {
+    throw Object({ error: 'validation error', reason: 'language field is undefined' });
+  }
+
+  if (data.language.name === undefined) {
+    throw Object({ error: 'validation error', reason: 'language.name field is undefined' });
+  }
+
+  if (data.language.version === undefined) {
+    throw Object({ error: 'validation error', reason: 'language.version field is undefined' });
+  }
+
+  if (data.language.allow === undefined) {
+    throw Object({ error: 'validation error', reason: 'language.allow field is undefined' });
+  }
+
+  if (data.supports === undefined) {
+    throw Object({ error: 'validation error', reason: 'supports field is undefined' });
+  }
+}
+
+const format = (data) => {
+  validate(data);
+
+  var pdu = {}
+
+  if (data !== undefined) {
+    pdu = extend(pdu, data);
+  }
+
+  const packet = JSON.stringify(pdu);
+
+  return factory.encapsulate(packet, factory.Id.TASK_RESULT);
+}
+
+module.exports = {
+  validate: validate,
+  format: format
+}

--- a/dwp/pdu/report.js
+++ b/dwp/pdu/report.js
@@ -42,6 +42,12 @@ var validate = function validate (data) {
       throw Object({ error: 'validation error', reason: 'tasks is undefined' })
     }
   }
+
+  if (data.flags & Flags.SUPPORTED_LANGUAGES) {
+    if (data.languages === undefined) {
+      throw Object({ error: 'validation error', reason: 'languages is undefined' })
+    }
+  }
 }
 
 var format = function format (data) {


### PR DESCRIPTION
* Adiciona uma flag `SUPPORTED_LANGUAGES` no protocolo `get_report`. Requisita todas as linguagens pré-definidas como suportadas e se o _worker_ aceita outras linguagens (que devem ser testadas anteriormente)
* Adiciona protocolos:
    * `get_language_support`: Enviado do _dispatcher_ para o _worker_, quando o _dispatcher_ quer saber se o _worker_ tem suporte à linguagem especificada.
    * `language_support`: Resposta do _worker_ ao _dispatcher_, dizendo se a linguagem requerida é ou não suportada pelo _worker_
    * `get_language_command`: Enviado do _worker_ para o _dispatcher_, envia o nome de uma linguagem para receber como resposta o comando para saber se a linguagem é suportada (e sua versão)
    * `get_command`: Resposta do _dispatcher_ ao _worker_, dizendo o comando de teste da linguagem requisitada.

Problema descrito no issue #1 